### PR TITLE
Add commit search

### DIFF
--- a/github-digest/commits.graphql
+++ b/github-digest/commits.graphql
@@ -1,0 +1,9 @@
+{
+  nodes(ids: %s) {
+    ... on Commit {
+      associatedPullRequests(first: 1) {
+        totalCount
+      }
+    }
+  }
+}

--- a/github-digest/main.py
+++ b/github-digest/main.py
@@ -11,9 +11,27 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
 from typing import Literal, Iterator
+from urllib.parse import quote
 
 import msgspec
 import requests
+
+
+ROOT = Path(__file__).absolute().parent
+
+IGNORE_AUTHORS = {
+    "jcrist",
+    "dependabot",
+    "renovate",
+    "phillip-ground",
+    "ibis-squawk-bot",
+}
+
+IGNORE_REPOS = {
+    "jcrist/msgspec",
+    "conda-forge/msgspec-feedstock",
+    "NixOS/nixpkgs",
+}
 
 
 class Repo(msgspec.Struct, rename="camel"):
@@ -64,13 +82,57 @@ class SearchResults(msgspec.Struct):
     data: _Search1
 
 
-def fetch_recent_items(token: str, since: datetime.date) -> list[Item]:
-    root = Path(__file__).absolute().parent
+class Commit(msgspec.Struct):
+    class Repository(msgspec.Struct):
+        full_name: str
+
+    class CommitInfo(msgspec.Struct):
+        class Author(msgspec.Struct):
+            name: str
+
+        class Committer(msgspec.Struct):
+            date: datetime.datetime
+
+        author: Author
+        committer: Committer
+        message: str
+
+        @property
+        def title(self) -> str:
+            return self.message.splitlines()[0].strip()
+
+    sha: str
+    html_url: str
+    node_id: str
+    repo: Repository = msgspec.field(name="repository")
+    info: CommitInfo = msgspec.field(name="commit")
+
+
+class CommitSearchResults(msgspec.Struct):
+    total_count: int
+    items: list[Commit]
+
+
+class CommitNodesResults(msgspec.Struct, rename="camel"):
+    class Data(msgspec.Struct, rename="camel"):
+        class CommitNode(msgspec.Struct, rename="camel"):
+            class PullRequests(msgspec.Struct, rename="camel"):
+                total_count: int
+
+            associated_pull_requests: PullRequests
+
+        nodes: list[CommitNode]
+
+    data: Data
+
+
+def fetch_recent_items(token: str, after: datetime.datetime) -> list[Item]:
     with requests.Session() as session:
-        search = f"msgspec updated:>={since}"
+        search = f"msgspec updated:>={after.date()}"
         items = []
+        # Fetch recent issues, PRs, and discussions
         for file in ["issues.graphql", "discussions.graphql"]:
-            with open(root / file, "r") as f:
+            with open(ROOT / file, "r") as f:
                 template = f.read()
             cursor = None
             while True:
@@ -84,32 +146,13 @@ def fetch_recent_items(token: str, since: datetime.date) -> list[Item]:
                     headers={"Authorization": f"bearer {token}"},
                     json={"query": query},
                 )
+                resp.raise_for_status()
                 msg = msgspec.json.decode(resp.content, type=SearchResults).data.search
                 items.extend(msg.items)
                 if msg.page_info.has_next_page:
                     cursor = msg.page_info.end_cursor
                 else:
                     break
-        return items
-
-
-def select_interesting_items(items: list[Item], since: datetime.date) -> list[Item]:
-    # Find everything interesting after 9 central (14 UTC) yesterday
-    after = datetime.datetime.combine(
-        since, datetime.time(14, tzinfo=datetime.timezone.utc)
-    )
-    IGNORE_AUTHORS = {
-        "jcrist",
-        "dependabot",
-        "renovate",
-        "phillip-ground",
-        "ibis-squawk-bot",
-    }
-    IGNORE_REPOS = {
-        "jcrist/msgspec",
-        "conda-forge/msgspec-feedstock",
-        "NixOS/nixpkgs",
-    }
     return [
         item
         for item in items
@@ -127,7 +170,57 @@ def select_interesting_items(items: list[Item], since: datetime.date) -> list[It
     ]
 
 
-def format_plain(groups: dict[str, list[Item]]) -> str:
+def fetch_recent_commits(token: str, after: datetime.datetime) -> list[Commit]:
+    commits = []
+
+    with requests.Session() as session:
+        # Fetch recent commits. This isn't exposed through graphql currently.
+        query = quote(f"msgspec committer-date:>={after.date()}")
+        resp = session.get(  # type: ignore
+            (
+                f"https://api.github.com/search/commits"
+                f"?q={query}&sort=committer-date&order=desc&per_page=100"
+            ),
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        resp.raise_for_status()
+        commit_search = msgspec.json.decode(resp.content, type=CommitSearchResults)
+
+        if commit_search.items:
+            node_ids = [commit.node_id for commit in commit_search.items]
+
+            # Filter out commits that have an associated PR. This can only be
+            # done by graphql.
+            with open(ROOT / "commits.graphql", "r") as f:
+                template = f.read()
+            query = template % msgspec.json.encode(node_ids).decode()
+            resp = session.post(  # type: ignore
+                "https://api.github.com/graphql",
+                headers={"Authorization": f"bearer {token}"},
+                json={"query": query},
+            )
+            resp.raise_for_status()
+            nodes = msgspec.json.decode(
+                resp.content, type=CommitNodesResults
+            ).data.nodes
+            for commit, node in zip(commit_search.items, nodes):
+                if node.associated_pull_requests.total_count == 0:
+                    commits.append(commit)
+
+    return [
+        commit
+        for commit in commits
+        if commit.info.committer.date >= after
+        and commit.info.author.name not in IGNORE_AUTHORS
+        and commit.repo.full_name not in IGNORE_REPOS
+    ]
+
+
+def format_plain(groups: dict[str, list[Item | Commit]]) -> str:
     def gen() -> Iterator[str]:
         first = True
         for repo, items in sorted(groups.items()):
@@ -137,13 +230,18 @@ def format_plain(groups: dict[str, list[Item]]) -> str:
                 first = False
             yield f"**{repo}**"
             for item in items:
-                label = "PR" if item.type == "PullRequest" else item.type
-                yield f"- {label} #{item.number}: {item.title} <{item.url}>"
+                if isinstance(item, Item):
+                    label = "PR" if item.type == "PullRequest" else item.type
+                    yield f"- {label} #{item.number}: {item.title} <{item.url}>"
+                else:
+                    yield (
+                        f"- Commit {item.sha[:8]}: {item.info.title} <{item.html_url}>"
+                    )
 
     return "\n".join(gen())
 
 
-def format_html(groups: dict[str, list[Item]]) -> str:
+def format_html(groups: dict[str, list[Item | Commit]]) -> str:
     def gen() -> Iterator[str]:
         first = True
         yield '<div dir="ltr">'
@@ -154,14 +252,21 @@ def format_html(groups: dict[str, list[Item]]) -> str:
                 first = False
             yield f"<div><b>{repo}</b></div>"
             for item in items:
-                label = "PR" if item.type == "PullRequest" else item.type
-                title = html.escape(item.title)
-                count = item.comments.total_count + item.reviews.total_count
-                suffix = f" <i>({count} comments)</i>" if count else ""
-                yield (
-                    f'<div>- <a href="{item.url}">{label} #{item.number}</a>'
-                    f": {title}{suffix}</div>"
-                )
+                if isinstance(item, Item):
+                    label = "PR" if item.type == "PullRequest" else item.type
+                    title = html.escape(item.title)
+                    count = item.comments.total_count + item.reviews.total_count
+                    suffix = f" <i>({count} comments)</i>" if count else ""
+                    yield (
+                        f'<div>- <a href="{item.url}">{label} #{item.number}</a>'
+                        f": {title}{suffix}</div>"
+                    )
+                else:
+                    title = html.escape(item.info.title)
+                    yield (
+                        f'<div>- <a href="{item.html_url}">Commit {item.sha[:8]}</a>'
+                        f": {title}</div>"
+                    )
         yield "</div>"
 
     return "".join(gen())
@@ -201,13 +306,20 @@ def main() -> None:
 
     today = datetime.date.today()
     yesterday = today - datetime.timedelta(days=1)
-    items = fetch_recent_items(GH_TOKEN, yesterday)
-    items = select_interesting_items(items, yesterday)
+    # Find everything interesting after 9 central (14 UTC) yesterday
+    after = datetime.datetime.combine(
+        yesterday, datetime.time(14, tzinfo=datetime.timezone.utc)
+    )
 
-    if items:
-        groups = defaultdict(list)
+    items = fetch_recent_items(GH_TOKEN, after)
+    commits = fetch_recent_commits(GH_TOKEN, after)
+
+    if items or commits:
+        groups: defaultdict[str, list[Item | Commit]] = defaultdict(list)
         for item in items:
             groups[item.repo.name_with_owner].append(item)
+        for commit in commits:
+            groups[commit.repo.full_name].append(commit)
         plain = format_plain(groups)
         html = format_html(groups)
         subject = f"GitHub Search Digest: msgspec ({today})"


### PR DESCRIPTION
This adds commits to the searched types. We filter out commits that have corresponding PRs (since those PRs are likely to mention `msgspec` themselves anyway). Unfortunately commit search isn't exposed through graphql yet, so we have to make use of both the REST and graphql APIs to get the info we want.